### PR TITLE
改进模板引擎

### DIFF
--- a/ThinkPHP/Library/Think/Template.class.php
+++ b/ThinkPHP/Library/Think/Template.class.php
@@ -10,28 +10,25 @@
 // +----------------------------------------------------------------------
 namespace Think;
 
-/**
- * ThinkPHP内置模板引擎类
- * 支持XML标签和普通标签的模板解析
- * 编译型模板引擎 支持动态缓存
- */
 use Think\Hook as Hook;
 //use Think\Crypt\Driver\Think as Think;
 use Think\Storage as Storage;
 use Think\Think as Think;
 
-class Template
+/**
+ * ThinkPHP内置模板引擎类
+ * 支持XML标签和普通标签的模板解析
+ * 编译型模板引擎 支持动态缓存
+ */
+class  Template
 {
 
-    // 模板页面中引入的标签库列表
-    protected $tagLib = array();
     // 当前模板文件
     protected $templateFile = '';
     // 模板变量
-    public $tVar     = array();
-    public $config   = array();
+    public $tVar = array();
+    public $config = array();
     private $literal = array();
-    private $block   = array();
 
     /**
      * 架构函数
@@ -52,6 +49,12 @@ class Template
         $this->config['layout_item']     = C('TMPL_LAYOUT_ITEM');
     }
 
+    /**
+     * 标签位转换
+     * @access private
+     * @param  string $str 标签位
+     * @return string
+     */
     private function stripPreg($str)
     {
         return str_replace(
@@ -60,7 +63,12 @@ class Template
             $str);
     }
 
-    // 模板变量获取和设置
+    /**
+     * 模板变量获取
+     * @access public
+     * @param  string $name 变量名
+     * @return string|false
+     */
     public function get($name)
     {
         if (isset($this->tVar[$name])) {
@@ -68,9 +76,15 @@ class Template
         } else {
             return false;
         }
-
     }
 
+    /**
+     * 模板变量设置
+     * @access public
+     * @param  string $name 变量名
+     * @param  string $value 变量值
+     * @return void
+     */
     public function set($name, $value)
     {
         $this->tVar[$name] = $value;
@@ -79,9 +93,9 @@ class Template
     /**
      * 加载模板
      * @access public
-     * @param string $templateFile 模板文件
-     * @param array  $templateVar 模板变量
-     * @param string $prefix 模板标识前缀
+     * @param  string $templateFile 模板文件
+     * @param  array $templateVar 模板变量
+     * @param  string $prefix 模板标识前缀
      * @return void
      */
     public function fetch($templateFile, $templateVar, $prefix = '')
@@ -94,8 +108,8 @@ class Template
     /**
      * 加载主模板并缓存
      * @access public
-     * @param string $templateFile 模板文件
-     * @param string $prefix 模板标识前缀
+     * @param  string $templateFile 模板文件
+     * @param  string $prefix 模板标识前缀
      * @return string
      * @throws ThinkExecption
      */
@@ -116,8 +130,7 @@ class Template
             if (false !== strpos($tmplContent, '{__NOLAYOUT__}')) {
                 // 可以单独定义不使用布局
                 $tmplContent = str_replace('{__NOLAYOUT__}', '', $tmplContent);
-            } else {
-                // 替换布局的主体内容
+            } else { // 替换布局的主体内容
                 $layoutFile = THEME_PATH . C('LAYOUT_NAME') . $this->config['template_suffix'];
                 // 检查布局文件
                 if (!is_file($layoutFile)) {
@@ -138,16 +151,14 @@ class Template
      * @param mixed $tmplContent 模板内容
      * @return string
      */
-    protected function compiler($tmplContent)
+    protected function compiler(&$tmplContent)
     {
         //模板解析
-        $tmplContent = $this->parse($tmplContent);
-        // 还原被替换的Literal标签
-        $tmplContent = preg_replace_callback('/<!--###literal(\d+)###-->/is', array($this, 'restoreLiteral'), $tmplContent);
+        $this->parse($tmplContent);
         // 添加安全代码
         $tmplContent = '<?php if (!defined(\'THINK_PATH\')) exit();?>' . $tmplContent;
         // 优化生成的php代码
-        $tmplContent = str_replace('?><?php', '', $tmplContent);
+        $tmplContent = preg_replace('/\?>\s*<\?php\s?/is', '', $tmplContent);
         // 模版编译过滤标签
         Hook::listen('template_filter', $tmplContent);
         return strip_whitespace($tmplContent);
@@ -157,24 +168,26 @@ class Template
      * 模板解析入口
      * 支持普通标签和TagLib解析 支持自定义标签库
      * @access public
-     * @param string $content 要解析的模板内容
-     * @return string
+     * @param  string $content 要解析的模板内容
+     * @return viod
      */
-    public function parse($content)
+    public function parse(&$content)
     {
         // 内容为空不解析
         if (empty($content)) {
-            return '';
+            return;
         }
-
-        $begin = $this->config['taglib_begin'];
-        $end   = $this->config['taglib_end'];
+        // 解析继承
+        $this->parseExtend($content);
+        // 解析布局
+        $this->parseLayout($content);
         // 检查include语法
-        $content = $this->parseInclude($content);
+        $this->parseInclude($content);
         // 检查PHP语法
-        $content = $this->parsePhp($content);
-        // 首先替换literal标签内容
-        $content = preg_replace_callback('/' . $begin . 'literal' . $end . '(.*?)' . $begin . '\/literal' . $end . '/is', array($this, 'parseLiteral'), $content);
+        $this->parsePhp($content);
+
+        // 替换literal标签内容
+        $this->parseLiteral($content);
 
         // 获取需要引入的标签库列表
         // 标签库只需要定义一次，允许引入多个一次
@@ -182,11 +195,11 @@ class Template
         // 格式：<taglib name="html,mytag..." />
         // 当TAGLIB_LOAD配置为true时才会进行检测
         if (C('TAGLIB_LOAD')) {
-            $this->getIncludeTagLib($content);
-            if (!empty($this->tagLib)) {
+            $tagLibs = $this->getIncludeTagLib($content);
+            if (!empty($tagLibs)) {
                 // 对导入的TagLib进行解析
-                foreach ($this->tagLib as $tagLibName) {
-                    $this->parseTagLib($tagLibName, $content);
+                foreach ($tagLibs as $tag) {
+                    $this->parseTagLib($tag, $content);
                 }
             }
         }
@@ -202,13 +215,21 @@ class Template
         foreach ($tagLibs as $tag) {
             $this->parseTagLib($tag, $content, true);
         }
-        //解析普通模板标签 {$tagName}
-        $content = preg_replace_callback('/(' . $this->config['tmpl_begin'] . ')([^\d\w\s' . $this->config['tmpl_begin'] . $this->config['tmpl_end'] . '].+?)(' . $this->config['tmpl_end'] . ')/is', array($this, 'parseTag'), $content);
-        return $content;
+        // 解析普通模板标签 {$tagName}
+        $this->parseTag($content);
+
+        // 还原被替换的Literal标签
+        $this->parseLiteral($content, true);
+        return;
     }
 
-    // 检查PHP语法
-    protected function parsePhp($content)
+    /**
+     * 检查PHP语法
+     * @access protected
+     * @param  string $content 要解析的模板内容
+     * @return void
+     */
+    protected function parsePhp(&$content)
     {
         if (ini_get('short_open_tag')) {
             // 开启短标签的情况要将<?标签用echo方式输出 否则无法正常输出xml标识
@@ -218,223 +239,213 @@ class Template
         if (C('TMPL_DENY_PHP') && false !== strpos($content, '<?php')) {
             E(L('_NOT_ALLOW_PHP_'));
         }
-        return $content;
+        return;
     }
 
-    // 解析模板中的布局标签
-    protected function parseLayout($content)
+    /**
+     * 解析模板中的布局标签
+     * @access protected
+     * @param  string $content 要解析的模板内容
+     * @return void
+     */
+    protected function parseLayout(&$content)
     {
         // 读取模板中的布局标签
-        $find = preg_match('/' . $this->config['taglib_begin'] . 'layout\s(.+?)\s*?\/' . $this->config['taglib_end'] . '/is', $content, $matches);
-        if ($find) {
+        if (preg_match($this->getRegex('layout'), $content, $matches)) {
             //替换Layout标签
             $content = str_replace($matches[0], '', $content);
             //解析Layout标签
-            $array = $this->parseXmlAttrs($matches[1]);
+            $array = $this->parseAttr($matches[0]);
             if (!C('LAYOUT_ON') || C('LAYOUT_NAME') != $array['name']) {
                 // 读取布局模板
                 $layoutFile = THEME_PATH . $array['name'] . $this->config['template_suffix'];
-                $replace    = isset($array['replace']) ? $array['replace'] : $this->config['layout_item'];
-                // 替换布局的主体内容
-                $content = str_replace($replace, $content, file_get_contents($layoutFile));
+                if (is_file($layoutFile)) {
+                    $replace = isset($array['replace']) ? $array['replace'] : $this->config['layout_item'];
+                    // 替换布局的主体内容
+                    $content = str_replace($replace, $content, file_get_contents($layoutFile));
+                }
             }
         } else {
             $content = str_replace('{__NOLAYOUT__}', '', $content);
-        }
-        return $content;
-    }
-
-    // 解析模板中的include标签
-    protected function parseInclude($content, $extend = true)
-    {
-        // 解析继承
-        if ($extend) {
-            $content = $this->parseExtend($content);
-        }
-
-        // 解析布局
-        $content = $this->parseLayout($content);
-        // 读取模板中的include标签
-        $find = preg_match_all('/' . $this->config['taglib_begin'] . 'include\s(.+?)\s*?\/' . $this->config['taglib_end'] . '/is', $content, $matches);
-        if ($find) {
-            for ($i = 0; $i < $find; $i++) {
-                $include = $matches[1][$i];
-                $array   = $this->parseXmlAttrs($include);
-                $file    = $array['file'];
-                unset($array['file']);
-                $content = str_replace($matches[0][$i], $this->parseIncludeItem($file, $array, $extend), $content);
-            }
-        }
-        return $content;
-    }
-
-    // 解析模板中的extend标签
-    protected function parseExtend($content)
-    {
-        $begin = $this->config['taglib_begin'];
-        $end   = $this->config['taglib_end'];
-        // 读取模板中的继承标签
-        $find = preg_match('/' . $begin . 'extend\s(.+?)\s*?\/' . $end . '/is', $content, $matches);
-        if ($find) {
-            //替换extend标签
-            $content = str_replace($matches[0], '', $content);
-            // 记录页面中的block标签
-            preg_replace_callback('/' . $begin . 'block\sname=[\'"](.+?)[\'"]\s*?' . $end . '(.*?)' . $begin . '\/block' . $end . '/is', array($this, 'parseBlock'), $content);
-            // 读取继承模板
-            $array   = $this->parseXmlAttrs($matches[1]);
-            $content = $this->parseTemplateName($array['name']);
-            $content = $this->parseInclude($content, false); //对继承模板中的include进行分析
-            // 替换block标签
-            $content = $this->replaceBlock($content);
-        } else {
-            $content = preg_replace_callback('/' . $begin . 'block\sname=[\'"](.+?)[\'"]\s*?' . $end . '(.*?)' . $begin . '\/block' . $end . '/is', function ($match) {return stripslashes($match[2]);}, $content);
-        }
-        return $content;
-    }
-
-    /**
-     * 分析XML属性
-     * @access private
-     * @param string $attrs  XML属性字符串
-     * @return array
-     */
-    private function parseXmlAttrs($attrs)
-    {
-        $xml = '<tpl><tag ' . $attrs . ' /></tpl>';
-        $xml = simplexml_load_string($xml);
-        if (!$xml) {
-            E(L('_XML_TAG_ERROR_'));
-        }
-
-        $xml   = (array) ($xml->tag->attributes());
-        $array = array_change_key_case($xml['@attributes']);
-        return $array;
-    }
-
-    /**
-     * 替换页面中的literal标签
-     * @access private
-     * @param string $content  模板内容
-     * @return string|false
-     */
-    private function parseLiteral($content)
-    {
-        if (is_array($content)) {
-            $content = $content[1];
-        }
-
-        if (trim($content) == '') {
-            return '';
-        }
-
-        //$content            =   stripslashes($content);
-        $i                 = count($this->literal);
-        $parseStr          = "<!--###literal{$i}###-->";
-        $this->literal[$i] = $content;
-        return $parseStr;
-    }
-
-    /**
-     * 还原被替换的literal标签
-     * @access private
-     * @param string $tag  literal标签序号
-     * @return string|false
-     */
-    private function restoreLiteral($tag)
-    {
-        if (is_array($tag)) {
-            $tag = $tag[1];
-        }
-
-        // 还原literal标签
-        $parseStr = $this->literal[$tag];
-        // 销毁literal记录
-        unset($this->literal[$tag]);
-        return $parseStr;
-    }
-
-    /**
-     * 记录当前页面中的block标签
-     * @access private
-     * @param string $name block名称
-     * @param string $content  模板内容
-     * @return string
-     */
-    private function parseBlock($name, $content = '')
-    {
-        if (is_array($name)) {
-            $content = $name[2];
-            $name    = $name[1];
-        }
-        $this->block[$name] = $content;
-        return '';
-    }
-
-    /**
-     * 替换继承模板中的block标签
-     * @access private
-     * @param string $content  模板内容
-     * @return string
-     */
-    private function replaceBlock($content)
-    {
-        static $parse = 0;
-        $begin        = $this->config['taglib_begin'];
-        $end          = $this->config['taglib_end'];
-        $reg          = '/(' . $begin . 'block\sname=[\'"](.+?)[\'"]\s*?' . $end . ')(.*?)' . $begin . '\/block' . $end . '/is';
-        if (is_string($content)) {
-            do {
-                $content = preg_replace_callback($reg, array($this, 'replaceBlock'), $content);
-            } while ($parse && $parse--);
-            return $content;
-        } elseif (is_array($content)) {
-            if (preg_match('/' . $begin . 'block\sname=[\'"](.+?)[\'"]\s*?' . $end . '/is', $content[3])) {
-                //存在嵌套，进一步解析
-                $parse      = 1;
-                $content[3] = preg_replace_callback($reg, array($this, 'replaceBlock'), "{$content[3]}{$begin}/block{$end}");
-                return $content[1] . $content[3];
-            } else {
-                $name    = $content[2];
-                $content = $content[3];
-                $content = isset($this->block[$name]) ? $this->block[$name] : $content;
-                return $content;
-            }
-        }
-    }
-
-    /**
-     * 搜索模板页面中包含的TagLib库
-     * 并返回列表
-     * @access public
-     * @param string $content  模板内容
-     * @return string|false
-     */
-    public function getIncludeTagLib(&$content)
-    {
-        //搜索是否有TagLib标签
-        $find = preg_match('/' . $this->config['taglib_begin'] . 'taglib\s(.+?)(\s*?)\/' . $this->config['taglib_end'] . '\W/is', $content, $matches);
-        if ($find) {
-            //替换TagLib标签
-            $content = str_replace($matches[0], '', $content);
-            //解析TagLib标签
-            $array        = $this->parseXmlAttrs($matches[1]);
-            $this->tagLib = explode(',', $array['name']);
         }
         return;
     }
 
     /**
+     * 解析模板中的include标签
+     * @access protected
+     * @param  string $content 要解析的模板内容
+     * @return void
+     */
+    protected function parseInclude(&$content)
+    {
+        $regex      = $this->getRegex('include');
+        $self       = &$this;
+        $funReplace = function ($template) use (&$funReplace, &$regex, &$content, &$self) {
+            if (preg_match_all($regex, $template, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $array = $self->parseAttr($match[0]);
+                    $file  = $array['file'];
+                    unset($array['file']);
+                    // 分析模板文件名并读取内容
+                    $parseStr = $self->parseTemplateName($file);
+                    // 替换变量
+                    foreach ($array as $k => $v) {
+                        $parseStr = str_replace('[' . $k . ']', $v, $parseStr);
+                    }
+                    // 再次对包含文件进行模板分析
+                    $funReplace($parseStr);
+                    $content = str_replace($match[0], $parseStr, $content);
+                }
+                unset($matches);
+            }
+        };
+        // 替换模板中的include标签
+        $funReplace($content);
+        return;
+    }
+
+    /**
+     * 解析模板中的extend标签
+     * @access protected
+     * @param  string $content 要解析的模板内容
+     * @return void
+     */
+    protected function parseExtend(&$content)
+    {
+        $regex  = $this->getRegex('extend');
+        $flag   = array();
+        $blocks = $extBlocks = array();
+        $extend = '';
+        $self   = &$this;
+        $fun    = function ($template) use (&$self, &$fun, &$regex, &$flag, &$extend, &$blocks, &$extBlocks) {
+            if (preg_match($regex, $template, $matches)) {
+                if (!isset($flag[$matches['name']])) {
+                    $flag[$matches['name']] = 1;
+                    // 读取继承模板
+                    $extend = $self->parseTemplateName($matches['name']);
+                    // 递归检查继承
+                    $fun($extend);
+                    // 取得block标签内容
+                    $blocks = array_merge($blocks, $self->parseBlock($template));
+                    return;
+                }
+            } else {
+                // 取得顶层模板block标签内容
+                $extBlocks = $self->parseBlock($template);
+                if (empty($extend)) {
+                    // 无extend标签但有block标签的情况
+                    $extend = $template;
+                }
+            }
+        };
+
+        $fun($content);
+        if (!empty($extend)) {
+            if ($extBlocks) {
+                foreach ($extBlocks as $name => $v) {
+                    $replace = isset($blocks[$name]) ? $blocks[$name]['content'] : $v['content'];
+                    $extend  = str_replace($v['begin']['tag'] . $v['content'] . $v['end']['tag'], $replace, $extend);
+                }
+            }
+            $content = $extend;
+        }
+        return;
+    }
+
+    /**
+     * 替换页面中的literal标签
+     * @access private
+     * @param  string $content 模板内容
+     * @return void
+     */
+    private function parseLiteral(&$content, $restore = false)
+    {
+        $regex = $this->getRegex($restore ? 'restoreliteral' : 'literal');
+        if (preg_match_all($regex, $content, $matches, PREG_SET_ORDER)) {
+            if (!$restore) {
+                // 替换literal标签
+                foreach ($matches as $i => $match) {
+                    $this->literal[$i] = substr($match[0], strlen($match[1]), -strlen($match[2]));
+                    $content           = str_replace($match[0], "<!--###literal{$i}###-->", $content);
+                }
+            } else {
+                // 还原literal标签
+                foreach ($matches as $i => $match) {
+                    $content = str_replace($match[0], $this->literal[$i], $content);
+                }
+                // 销毁literal记录
+                unset($this->literal);
+            }
+            unset($matches);
+        }
+        return;
+    }
+
+    /**
+     * 获取模板中的block标签
+     * @access protected
+     * @param  string $content 模板内容
+     * @return array
+     */
+    protected function parseBlock(&$content)
+    {
+        $regex = $this->getRegex('block');
+        $array = array();
+        if (preg_match_all($regex, $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+            $right = array();
+            foreach ($matches as $match) {
+                if (empty($match['name'][0])) {
+                    if (!empty($right)) {
+                        $begin                 = array_pop($right);
+                        $end                   = array('offset' => $match[0][1], 'tag' => $match[0][0]);
+                        $start                 = $begin['offset'] + strlen($begin['tag']);
+                        $len                   = $end['offset'] - $start;
+                        $array[$begin['name']] = array(
+                            'begin'   => $begin,
+                            'content' => substr($content, $start, $len),
+                            'end'     => $end,
+                        );
+                    } else {
+                        continue;
+                    }
+                } else {
+                    $right[] = array('name' => $match[2][0], 'offset' => $match[0][1], 'tag' => $match[0][0]);
+                }
+            }
+            unset($right, $matches);
+        }
+        return $array;
+    }
+
+    /**
+     * 搜索模板页面中包含的TagLib库
+     * 并返回列表
+     * @access protected
+     * @param  string $content 模板内容
+     * @return array|null
+     */
+    protected function getIncludeTagLib(&$content)
+    {
+        // 搜索是否有TagLib标签
+        if (preg_match($this->getRegex('taglib'), $content, $matches)) {
+            // 替换TagLib标签
+            $content = str_replace($matches[0], '', $content);
+            return explode(',', $matches['name']);
+        }
+        return null;
+    }
+
+    /**
      * TagLib库解析
      * @access public
-     * @param string $tagLib 要解析的标签库
-     * @param string $content 要解析的模板内容
-     * @param boolean $hide 是否隐藏标签库前缀
-     * @return string
+     * @param  string $tagLib 要解析的标签库
+     * @param  string $content 要解析的模板内容
+     * @param  boolean $hide 是否隐藏标签库前缀
+     * @return void
      */
     public function parseTagLib($tagLib, &$content, $hide = false)
     {
-        $begin = $this->config['taglib_begin'];
-        $end   = $this->config['taglib_end'];
         if (strpos($tagLib, '\\')) {
             // 支持指定标签库的命名空间
             $className = $tagLib;
@@ -442,341 +453,317 @@ class Template
         } else {
             $className = 'Think\\Template\TagLib\\' . ucwords($tagLib);
         }
-        $tLib = \Think\Think::instance($className);
-        $that = $this;
-        foreach ($tLib->getTags() as $name => $val) {
-            $tags = array($name);
-            if (isset($val['alias'])) {
-// 别名设置
-                $tags   = explode(',', $val['alias']);
-                $tags[] = $name;
-            }
-            $level    = isset($val['level']) ? $val['level'] : 1;
-            $closeTag = isset($val['close']) ? $val['close'] : true;
-            foreach ($tags as $tag) {
-                $parseTag = !$hide ? $tagLib . ':' . $tag : $tag; // 实际要解析的标签名称
-                if (!method_exists($tLib, '_' . $tag)) {
-                    // 别名可以无需定义解析方法
-                    $tag = $name;
-                }
-                $n1            = empty($val['attr']) ? '(\s*?)' : '\s([^' . $end . ']*)';
-                $this->tempVar = array($tagLib, $tag);
-
-                if (!$closeTag) {
-                    $patterns = '/' . $begin . $parseTag . $n1 . '\/(\s*?)' . $end . '/is';
-                    $content  = preg_replace_callback($patterns, function ($matches) use ($tLib, $tag, $that) {
-                        return $that->parseXmlTag($tLib, $tag, $matches[1], $matches[2]);
-                    }, $content);
-                } else {
-                    $patterns = '/' . $begin . $parseTag . $n1 . $end . '(.*?)' . $begin . '\/' . $parseTag . '(\s*?)' . $end . '/is';
-                    for ($i = 0; $i < $level; $i++) {
-                        $content = preg_replace_callback($patterns, function ($matches) use ($tLib, $tag, $that) {
-                            return $that->parseXmlTag($tLib, $tag, $matches[1], $matches[2]);
-                        }, $content);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * 解析标签库的标签
-     * 需要调用对应的标签库文件解析类
-     * @access public
-     * @param object $tagLib  标签库对象实例
-     * @param string $tag  标签名
-     * @param string $attr  标签属性
-     * @param string $content  标签内容
-     * @return string|false
-     */
-    public function parseXmlTag($tagLib, $tag, $attr, $content)
-    {
-        if (ini_get('magic_quotes_sybase')) {
-            $attr = str_replace('\"', '\'', $attr);
-        }
-
-        $parse   = '_' . $tag;
-        $content = trim($content);
-        $tags    = $tagLib->parseXmlAttr($attr, $tag);
-        return $tagLib->$parse($tags, $content);
+        $tagLib = strtolower($tagLib);
+        \Think\Think::instance($className)->parseTag($content, $hide ? '' : $tagLib);
+        return;
     }
 
     /**
      * 模板标签解析
      * 格式： {TagName:args [|content] }
      * @access public
-     * @param string $tagStr 标签内容
-     * @return string
+     * @param  string $tagStr 标签内容
+     * @return void
      */
-    public function parseTag($tagStr)
+    public function parseTag(&$content)
     {
-        if (is_array($tagStr)) {
-            $tagStr = $tagStr[2];
-        }
+        $regex = $this->getRegex('tag');
+        if (preg_match_all($regex, $content, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $str  = stripslashes($match[1]);
+                $flag = substr($str, 0, 1);
+                switch ($flag) {
+                    case '$': // 解析模板变量 格式 {$varName}
+                        $this->parseVar($str);
+                        // 是否带有?号
+                        if (false !== $pos = strpos($str, '?')) {
+                            $array = preg_split('/([!=]={1,2}|(?<!-)[><]={0,1})/', substr($str, 0, $pos), 2, PREG_SPLIT_DELIM_CAPTURE);
+                            $name  = trim($array[0]);
+                            $this->parseVarFunction($name);
 
-        //if (MAGIC_QUOTES_GPC) {
-        $tagStr = stripslashes($tagStr);
-        //}
-        $flag  = substr($tagStr, 0, 1);
-        $flag2 = substr($tagStr, 1, 1);
-        $name  = substr($tagStr, 1);
-        if ('$' == $flag && '.' != $flag2 && '(' != $flag2) {
-            //解析模板变量 格式 {$varName}
-            return $this->parseVar($name);
-        } elseif ('-' == $flag || '+' == $flag) {
-            // 输出计算
-            return '<?php echo ' . $flag . $name . ';?>';
-        } elseif (':' == $flag) {
-            // 输出某个函数的结果
-            return '<?php echo ' . $name . ';?>';
-        } elseif ('~' == $flag) {
-            // 执行某个函数
-            return '<?php ' . $name . ';?>';
-        } elseif (substr($tagStr, 0, 2) == '//' || (substr($tagStr, 0, 2) == '/*' && substr(rtrim($tagStr), -2) == '*/')) {
-            //注释标签
-            return '';
+                            $str   = trim(substr($str, $pos + 1));
+                            $first = substr($str, 0, 1);
+                            if (isset($array[1])) {
+                                // XXX: 加入这句原本是为解决变量末声明的问题，但$name中是多个条件时会解析错误，故注释掉
+                                /*if (strpos($name, '[')) {
+                                    $name = 'isset(' . $name . ') && ' . $name;
+                                }*/
+                                $name .= $array[1] . trim($array[2]);
+                                if ('=' == $first) {
+                                    // {$varname?='xxx'} $varname为真时才输出xxx
+                                    $str = '<?php if( ' . $name . ' ) echo ' . substr($str, 1) . '; ?>';
+                                } else {
+                                    $str = '<?php echo (' . $name . ') ? ' . $str . '; ?>';
+                                }
+                            } else {
+                                switch ($first) {
+                                    case '?':
+                                        // {$varname??'xxx'} $varname有定义则输出$varname,否则输出xxx
+                                        $str = '<?php echo isset(' . $name . ') ? ' . $name . ' : ' . substr($str, 1) . '; ?>';
+                                        break;
+                                    case '=':
+                                        // {$varname?='xxx'} $varname为真时才输出xxx
+                                        $str = '<?php if(!empty(' . $name . ')) echo ' . substr($str, 1) . '; ?>';
+                                        break;
+                                    case ':':
+                                        // {$varname?:'xxx'} $varname为真时输出$varname,否则输出xxx
+                                        $str = '<?php echo !empty(' . $name . ') ? ' . $name . $str . '; ?>';
+                                        break;
+                                    default:
+                                        if (strpos($str, ':')) {
+                                            // {$varname ? 'a' : 'b'} $varname为真时输出a,否则输出b
+                                            $str = '<?php echo !empty(' . $name . ') ? ' . $str . '; ?>';
+                                        } else {
+                                            $str = '<?php echo ' . $name . '?' . $str . '; ?>';
+                                        }
+                                }
+                            }
+                        } else {
+                            $this->parseVarFunction($str);
+                            $str = '<?php echo ' . $str . '; ?>';
+                        }
+                        break;
+                    case ':': // 输出某个函数的结果
+                        $str = substr($str, 1);
+                        $this->parseVar($str);
+                        $str = '<?php echo ' . $str . '; ?>';
+                        break;
+                    case '~': // 执行某个函数
+                        $str = substr($str, 1);
+                        $str = '<?php ' . $str . '; ?>';
+                        break;
+                    case '-':
+                    case '+': // 输出计算
+                        $str = '<?php echo ' . $str . '; ?>';
+                        break;
+                    case '/': // 注释标签
+                        $flag2 = substr($str, 1, 1);
+                        if ($flag2 == '/' || ($flag2 == '*' && substr(rtrim($str), -2) == '*/')) {
+                            $str = '';
+                        }
+                        break;
+                    default:
+                        static $_tmplDelimiter;
+                        if (is_null($_tmplDelimiter)) {
+                            $_tmplDelimiter = array(C('TMPL_L_DELIM'), C('TMPL_R_DELIM'));
+                        }
+                        // 未识别的标签直接返回
+                        $str = $_tmplDelimiter[0] . $str . $_tmplDelimiter[1];
+                        break;
+                }
+                $content = str_replace($match[0], $str, $content);
+            }
+            unset($matches);
         }
-        // 未识别的标签直接返回
-        return C('TMPL_L_DELIM') . $tagStr . C('TMPL_R_DELIM');
+        return;
     }
 
     /**
      * 模板变量解析,支持使用函数
      * 格式： {$varname|function1|function2=arg1,arg2}
      * @access public
-     * @param string $varStr 变量数据
-     * @return string
+     * @param  string $varStr 变量数据
+     * @return void
      */
-    public function parseVar($varStr)
+    public function parseVar(&$varStr)
     {
-        $varStr               = trim($varStr);
-        static $_varParseList = array();
-        //如果已经解析过该变量字串，则直接返回变量值
-        if (isset($_varParseList[$varStr])) {
-            return $_varParseList[$varStr];
-        }
-
-        $parseStr  = '';
-        $varExists = true;
-        if (!empty($varStr)) {
-            $varArray = explode('|', $varStr);
-            //取得变量名称
-            $var = array_shift($varArray);
-            if ('Think.' == substr($var, 0, 6)) {
-                // 所有以Think.打头的以特殊变量对待 无需模板赋值就可以输出
-                $name = $this->parseThinkVar($var);
-            } elseif (false !== strpos($var, '.')) {
-                //支持 {$var.property}
-                $vars = explode('.', $var);
-                $var  = array_shift($vars);
-                switch (strtolower(C('TMPL_VAR_IDENTIFY'))) {
-                    case 'array': // 识别为数组
-                        $name = '$' . $var;
-                        foreach ($vars as $key => $val) {
-                            $name .= '["' . $val . '"]';
+        $varStr = trim($varStr);
+        if (preg_match_all('/\$[a-zA-Z_](?>\w*)(?:[:\.][a-zA-Z_](?>\w*))+/', $varStr, $matches, PREG_OFFSET_CAPTURE)) {
+            static $_varParseList = array();
+            while ($matches[0]) {
+                $match = array_pop($matches[0]);
+                //如果已经解析过该变量字串，则直接返回变量值
+                if (isset($_varParseList[$match[0]])) {
+                    $parseStr = $_varParseList[$match[0]];
+                } else {
+                    if (strpos($match[0], '.')) {
+                        $vars  = explode('.', $match[0]);
+                        $first = array_shift($vars);
+                        if ($first == '$Think') {
+                            // 所有以Think.打头的以特殊变量对待 无需模板赋值就可以输出
+                            $parseStr = $this->parseThinkVar($vars);
+                        } else {
+                            switch (strtolower(C('TMPL_VAR_IDENTIFY'))) {
+                                case 'array': // 识别为数组
+                                    $parseStr = $first . '[\'' . implode('\'][\'', $vars) . '\']';
+                                    break;
+                                case 'obj':  // 识别为对象
+                                    $parseStr = $first . '->' . implode('->', $vars);
+                                    break;
+                                default:  // 自动判断数组或对象 只支持二维
+                                    $parseStr = 'is_array(' . $first . ')?' . $first . '[\'' . implode('\'][\'', $vars) . '\']:' . $first . '->' . implode('->', $vars);
+                            }
                         }
-
-                        break;
-                    case 'obj': // 识别为对象
-                        $name = '$' . $var;
-                        foreach ($vars as $key => $val) {
-                            $name .= '->' . $val;
-                        }
-
-                        break;
-                    default: // 自动判断数组或对象 只支持二维
-                        $name = 'is_array($' . $var . ')?$' . $var . '["' . $vars[0] . '"]:$' . $var . '->' . $vars[0];
+                    } else {
+                        $parseStr = str_replace(':', '->', $match[0]);
+                    }
+                    $_varParseList[$match[0]] = $parseStr;
                 }
-            } elseif (false !== strpos($var, '[')) {
-                //支持 {$var['key']} 方式输出数组
-                $name = "$" . $var;
-                preg_match('/(.+?)\[(.+?)\]/is', $var, $match);
-                $var = $match[1];
-            } elseif (false !== strpos($var, ':') && false === strpos($var, '(') && false === strpos($var, '::') && false === strpos($var, '?')) {
-                //支持 {$var:property} 方式输出对象的属性
-                $vars = explode(':', $var);
-                $var  = str_replace(':', '->', $var);
-                $name = "$" . $var;
-                $var  = $vars[0];
-            } else {
-                $name = "$$var";
+                $varStr = substr_replace($varStr, $parseStr, $match[1], strlen($match[0]));
             }
-            //对变量使用函数
-            if (count($varArray) > 0) {
-                $name = $this->parseVarFunction($name, $varArray);
-            }
-
-            $parseStr = '<?php echo (' . $name . '); ?>';
+            unset($matches);
         }
-        $_varParseList[$varStr] = $parseStr;
-        return $parseStr;
+        return;
     }
 
     /**
-     * 对模板变量使用函数
+     * 对模板中使用了函数的变量进行解析
      * 格式 {$varname|function1|function2=arg1,arg2}
      * @access public
-     * @param string $name 变量名
-     * @param array $varArray  函数列表
-     * @return string
+     * @param  string $varStr 变量字符串
+     * @return void
      */
-    public function parseVarFunction($name, $varArray)
+    public function parseVarFunction(&$varStr)
     {
-        //对变量使用函数
-        $length = count($varArray);
-        //取得模板禁止使用函数列表
-        $template_deny_funs = explode(',', C('TMPL_DENY_FUNC_LIST'));
-        for ($i = 0; $i < $length; $i++) {
-            $args = explode('=', $varArray[$i], 2);
-            //模板函数过滤
-            $fun = trim($args[0]);
-            switch ($fun) {
-                case 'default': // 特殊模板函数
-                    $name = '(isset(' . $name . ') && (' . $name . ' !== ""))?(' . $name . '):' . $args[1];
-                    break;
-                default: // 通用模板函数
-                    if (!in_array($fun, $template_deny_funs)) {
-                        if (isset($args[1])) {
-                            if (strstr($args[1], '###')) {
-                                $args[1] = str_replace('###', $name, $args[1]);
-                                $name    = "$fun($args[1])";
-                            } else {
-                                $name = "$fun($name,$args[1])";
-                            }
-                        } else if (!empty($args[0])) {
-                            $name = "$fun($name)";
-                        }
-                    }
-            }
+        if (false == strpos($varStr, '|')) {
+            return;
         }
-        return $name;
+        static $_varFunctionList = array();
+        //如果已经解析过该变量字串，则直接返回变量值
+        if (isset($_varFunctionList[$varStr])) {
+            $varStr = $_varFunctionList[$varStr];
+        } else {
+            $varArray = explode('|', $varStr);
+            // 取得变量名称
+            $name = array_shift($varArray);
+            // 对变量使用函数
+            $length = count($varArray);
+            // 取得模板禁止使用函数列表
+            $template_deny_funs = explode(',', C('TMPL_DENY_FUNC_LIST'));
+            for ($i = 0; $i < $length; $i++) {
+                $args = explode('=', $varArray[$i], 2);
+                // 模板函数过滤
+                $fun = trim($args[0]);
+                switch ($fun) {
+                    case 'default':  // 特殊模板函数
+                        $varStr = '(isset(' . $name . ') && (' . $name . ' !== \'\'))?(' . $name . '):' . $args[1];
+                        break;
+                    default:  // 通用模板函数
+                        if (!in_array($fun, $template_deny_funs)) {
+                            if (isset($args[1])) {
+                                if (strstr($args[1], '###')) {
+                                    $args[1] = str_replace('###', $name, $args[1]);
+                                    $name    = "$fun($args[1])";
+                                } else {
+                                    $varStr = "$fun($name,$args[1])";
+                                }
+                            } else {
+                                if (!empty($args[0])) {
+                                    $name = "$fun($name)";
+                                }
+                            }
+                        }
+                }
+            }
+            $varStr = $name;
+        }
+        return;
     }
 
     /**
      * 特殊模板变量解析
      * 格式 以 $Think. 打头的变量属于特殊模板变量
      * @access public
-     * @param string $varStr  变量字符串
+     * @param  array $vars 变量数组
      * @return string
      */
-    public function parseThinkVar($varStr)
+    public function parseThinkVar(&$vars)
     {
-        $vars     = explode('.', $varStr);
-        $vars[1]  = strtoupper(trim($vars[1]));
+        $vars[0]  = strtoupper(trim($vars[0]));
         $parseStr = '';
-        if (count($vars) >= 3) {
-            $vars[2] = trim($vars[2]);
-            switch ($vars[1]) {
+        if (count($vars) >= 2) {
+            $vars[1] = trim($vars[1]);
+            switch ($vars[0]) {
                 case 'SERVER':
-                    $parseStr = '$_SERVER[\'' . strtoupper($vars[2]) . '\']';
+                    $parseStr = '$_SERVER[\'' . strtoupper($vars[1]) . '\']';
                     break;
                 case 'GET':
-                    $parseStr = '$_GET[\'' . $vars[2] . '\']';
+                    $parseStr = '$_GET[\'' . $vars[1] . '\']';
                     break;
                 case 'POST':
-                    $parseStr = '$_POST[\'' . $vars[2] . '\']';
+                    $parseStr = '$_POST[\'' . $vars[1] . '\']';
                     break;
                 case 'COOKIE':
-                    if (isset($vars[3])) {
-                        $parseStr = '$_COOKIE[\'' . $vars[2] . '\'][\'' . $vars[3] . '\']';
+                    if (isset($vars[2])) {
+                        $parseStr = '$_COOKIE[\'' . $vars[1] . '\'][\'' . $vars[2] . '\']';
                     } else {
-                        $parseStr = 'cookie(\'' . $vars[2] . '\')';
+                        $parseStr = 'cookie(\'' . $vars[1] . '\')';
                     }
                     break;
                 case 'SESSION':
-                    if (isset($vars[3])) {
-                        $parseStr = '$_SESSION[\'' . $vars[2] . '\'][\'' . $vars[3] . '\']';
+                    if (isset($vars[2])) {
+                        $parseStr = '$_SESSION[\'' . $vars[1] . '\'][\'' . $vars[2] . '\']';
                     } else {
-                        $parseStr = 'session(\'' . $vars[2] . '\')';
+                        $parseStr = 'session(\'' . $vars[1] . '\')';
                     }
                     break;
                 case 'ENV':
-                    $parseStr = '$_ENV[\'' . strtoupper($vars[2]) . '\']';
+                    $parseStr = '$_ENV[\'' . strtoupper($vars[1]) . '\']';
                     break;
                 case 'REQUEST':
-                    $parseStr = '$_REQUEST[\'' . $vars[2] . '\']';
+                    $parseStr = '$_REQUEST[\'' . $vars[1] . '\']';
                     break;
                 case 'CONST':
-                    $parseStr = strtoupper($vars[2]);
+                    $parseStr = strtoupper($vars[1]);
                     break;
                 case 'LANG':
-                    $parseStr = 'L("' . $vars[2] . '")';
+                    $parseStr = 'L(\'' . $vars[1] . '\')';
                     break;
                 case 'CONFIG':
-                    if (isset($vars[3])) {
-                        $vars[2] .= '.' . $vars[3];
+                    if (isset($vars[2])) {
+                        $vars[1] .= '.' . $vars[2];
                     }
-                    $parseStr = 'C("' . $vars[2] . '")';
-                    break;
-                default:break;
-            }
-        } else if (count($vars) == 2) {
-            switch ($vars[1]) {
-                case 'NOW':
-                    $parseStr = "date('Y-m-d g:i a',time())";
-                    break;
-                case 'VERSION':
-                    $parseStr = 'THINK_VERSION';
-                    break;
-                case 'TEMPLATE':
-                    $parseStr = "'" . $this->templateFile . "'"; //'C("TEMPLATE_NAME")';
-                    break;
-                case 'LDELIM':
-                    $parseStr = 'C("TMPL_L_DELIM")';
-                    break;
-                case 'RDELIM':
-                    $parseStr = 'C("TMPL_R_DELIM")';
+                    $parseStr = 'C(\'' . $vars[1] . '\')';
                     break;
                 default:
-                    if (defined($vars[1])) {
-                        $parseStr = $vars[1];
-                    }
-
+                    break;
+            }
+        } else {
+            if (count($vars) == 1) {
+                switch ($vars[0]) {
+                    case 'NOW':
+                        $parseStr = "date('Y-m-d g:i a',time())";
+                        break;
+                    case 'VERSION':
+                        $parseStr = 'THINK_VERSION';
+                        break;
+                    case 'TEMPLATE':
+                        $parseStr = "'" . $this->templateFile . "'"; //'C("TEMPLATE_NAME")';
+                        break;
+                    case 'LDELIM':
+                        $parseStr = 'C("TMPL_L_DELIM")';
+                        break;
+                    case 'RDELIM':
+                        $parseStr = 'C("TMPL_R_DELIM")';
+                        break;
+                    default:
+                        if (defined($vars[0])) {
+                            $parseStr = $vars[0];
+                        }
+                }
             }
         }
         return $parseStr;
     }
 
     /**
-     * 加载公共模板并缓存 和当前模板在同一路径，否则使用相对路径
-     * @access private
-     * @param string $tmplPublicName  公共模板文件名
-     * @param array $vars  要传递的变量列表
-     * @return string
-     */
-    private function parseIncludeItem($tmplPublicName, $vars = array(), $extend)
-    {
-        // 分析模板文件名并读取内容
-        $parseStr = $this->parseTemplateName($tmplPublicName);
-        // 替换变量
-        foreach ($vars as $key => $val) {
-            $parseStr = str_replace('[' . $key . ']', $val, $parseStr);
-        }
-        // 再次对包含文件进行模板分析
-        return $this->parseInclude($parseStr, $extend);
-    }
-
-    /**
      * 分析加载的模板文件并读取内容 支持多个模板文件读取
-     * @access private
-     * @param string $tmplPublicName  模板文件名
+     * @access public
+     * @param  string $tmplPublicName 模板文件名
      * @return string
      */
-    private function parseTemplateName($templateName)
+    public function parseTemplateName($templateName)
     {
-        if (substr($templateName, 0, 1) == '$')
-        //支持加载变量文件名
-        {
+        if ('$' == substr($templateName, 0, 1)) {
+            //支持加载变量文件名
             $templateName = $this->get(substr($templateName, 1));
         }
-
         $array    = explode(',', $templateName);
         $parseStr = '';
         foreach ($array as $templateName) {
             if (empty($templateName)) {
                 continue;
             }
-
             if (false === strpos($templateName, $this->config['template_suffix'])) {
                 // 解析规则为 模块@主题/控制器/操作
                 $templateName = T($templateName);
@@ -785,5 +772,90 @@ class Template
             $parseStr .= file_get_contents($templateName);
         }
         return $parseStr;
+    }
+
+    /**
+     * 按标签生成正则
+     * @access private
+     * @param  string $tagName 标签名
+     * @return string
+     */
+    private function getRegex($tagName)
+    {
+        $begin  = $this->config['taglib_begin'];
+        $end    = $this->config['taglib_end'];
+        $single = strlen(ltrim($begin, '\\')) == 1 && strlen(ltrim($end, '\\')) == 1 ? true : false;
+        $regex  = '';
+        switch ($tagName) {
+            case 'block':
+                if ($single) {
+                    $regex = $begin . '(?:' . $tagName . '\b(?>(?:(?!name=).)*)\bname=([\'\"])(?<name>[\w\/\:@,]+)\\1(?>[^' . $end . ']*)|\/' . $tagName . ')' . $end;
+                } else {
+                    $regex = $begin . '(?:' . $tagName . '\b(?>(?:(?!name=).)*)\bname=([\'\"])(?<name>[\w\/\:@,]+)\\1(?>(?:(?!' . $end . ').)*)|\/' . $tagName . ')' . $end;
+                }
+                break;
+            case 'literal':
+                if ($single) {
+                    $regex = '(' . $begin . $tagName . '\b(?>[^' . $end . ']*)' . $end . ')';
+                    $regex .= '(?:(?>[^' . $begin . ']*)(?>(?!' . $begin . '(?>' . $tagName . '\b[^' . $end . ']*|\/' . $tagName . ')' . $end . ')' . $begin . '[^' . $begin . ']*)*)';
+                    $regex .= '(' . $begin . '\/' . $tagName . $end . ')';
+                } else {
+                    $regex = '(' . $begin . $tagName . '\b(?>(?:(?!' . $end . ').)*)' . $end . ')';
+                    $regex .= '(?:(?>(?:(?!' . $begin . ').)*)(?>(?!' . $begin . '(?>' . $tagName . '\b(?>(?:(?!' . $end . ').)*)|\/' . $tagName . ')' . $end . ')' . $begin . '(?>(?:(?!' . $begin . ').)*))*)';
+                    $regex .= '(' . $begin . '\/' . $tagName . $end . ')';
+                }
+                break;
+            case 'restoreliteral':
+                $regex = '<!--###literal(\d+)###-->';
+                break;
+            case 'include':
+                $name = 'file';
+            case 'taglib':
+            case 'layout':
+            case 'extend':
+                if (empty($name)) {
+                    $name = 'name';
+                }
+                if ($single) {
+                    $regex = $begin . $tagName . '\b(?>(?:(?!' . $name . '=).)*)\b' . $name . '=([\'\"])(?<name>[\w\/\:@,\\\\]+)\\1(?>[^' . $end . ']*)' . $end;
+                } else {
+                    $regex = $begin . $tagName . '\b(?>(?:(?!' . $name . '=).)*)\b' . $name . '=([\'\"])(?<name>[\w\/\:@,\\\\]+)\\1(?>(?:(?!' . $end . ').)*)' . $end;
+                }
+                break;
+            case 'tag':
+                $begin = $this->config['tmpl_begin'];
+                $end   = $this->config['tmpl_end'];
+                if (strlen(ltrim($begin, '\\')) == 1 && strlen(ltrim($end, '\\')) == 1) {
+                    $regex = $begin . '((?:[\$\:\-\+][a-wA-w_][\w\.\:\[\(\*\/\-\+\%_]|\/[\*\/])(?>[^' . $end . ']*))' . $end;
+                } else {
+                    $regex = $begin . '((?:[\$\:\-\+][a-wA-w_][\w\.\:\[\(\*\/\-\+\%_]|\/[\*\/])(?>(?:(?!' . $end . ').)*))' . $end;
+                }
+                break;
+        }
+        return '/' . $regex . '/is';
+    }
+
+    /**
+     * 分析标签属性
+     * @access public
+     * @param  string $str 属性字符串
+     * @param  string $name 不为空时返回指定的属性名
+     * @return array
+     */
+    public function parseAttr($str, $name = null)
+    {
+        $regex = '/\s+(?>(?<name>\w+)\s*)=(?>\s*)([\"\'])(?<value>(?:(?!\\2).)*)\\2/is';
+        $array = array();
+        if (preg_match_all($regex, $str, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $array[$match['name']] = $match['value'];
+            }
+            unset($matches);
+        }
+        if (!empty($name) && isset($array[$name])) {
+            return $array[$name];
+        } else {
+            return $array;
+        }
     }
 }


### PR DESCRIPTION
1.标签的替换过程和原来有所不同。先用正则查找出所有标签并记录下标签在模板中的位置，然后由后到前（这样才不会影响前面的标签）替换模板中的标签，不管同类标签嵌套多少层，都是在一个循环中完成，不需要递归。整体解析速度提升，也不用再限制标签层数。
 2. 兼容原来所有的标签功能和用法，已 对正则进行了优化，标签库和内置的普通标签可以使用一样的边界符，比如都用"{}"，只要不重名不会相互干扰，这样这些标签就可以和html标签区分开。
 3.模板支持多级继承。
 4. include标签支持多层嵌套，可以传变量。如：
include file="Public/nav" selected="{$id}"
 在Public/nav模板用[selected]得到的是[$id}被解析后的值，而在3.2版中这样的写法是不能正确得到{$id}的值的。
 5.增强了.语法的应用范围
 {$user.name.$group.name} 解析后是 <?php echo $user['name'].$group['name']; ?>
 {:substr($varname.aa, $varname.bb)} 解析后是 <?php echo substr($varname['aa'], $varname['bb']); ?>
 .语法在各个标签中都可以使用，$a.b.c这样的形式都能正确解析成$a['b']['c']
 6.增加了一些新的语法
 {$varname.aa ?? 'xxx'} 表示如果有设置$varname则输出$varname,否则输出'xxx'。 解析后的代码为： <?php echo isset($varname['aa']) ? $varname['aa'] : '默认值'; ?>
 {$varname?='xxx'} 表示$varname为真时才输出xxx。 解析后的代码为： <?php if(!empty($name)) echo 'xxx'; ?>
 {$varname ?: 'no'} 表示如果$varname为真则输出$varname，否则输出no。解析后的代码为： <?php echo $varname ? $varname : 'no'; ?>
 {$a==$b ? 'yes' : 'no'} 前面的表达式为真输出yes,否则输出no， 条件可以是==、===、!=、!==、>=、<= 
 7. 对if标签及foreach也加了一些更简洁的用法